### PR TITLE
Remove object indices

### DIFF
--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -67,7 +67,7 @@ class Model:
         name: Optional[str]
             Optional name of the job.
         """
-        job = Job(release_date=release_date, deadline=deadline, name=name)
+        job = Job(release_date, deadline, name)
         self._jobs.append(job)
         return job
 
@@ -80,7 +80,7 @@ class Model:
         name: Optional[str]
             Optional name of the machine.
         """
-        machine = Machine(name=name)
+        machine = Machine(name)
 
         self._machines.append(machine)
         self._machine_graph.add_node(len(self.machines))

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -80,10 +80,10 @@ class Model:
         name: Optional[str]
             Optional name of the machine.
         """
-        machine = Machine(len(self.machines), name)
+        machine = Machine(name=name)
 
         self._machines.append(machine)
-        self._machine_graph.add_node(machine.idx)
+        self._machine_graph.add_node(len(self.machines))
 
         return machine
 
@@ -136,4 +136,6 @@ class Model:
         )
 
     def add_machines_edge(self, machine1: Machine, machine2: Machine):
-        self._machine_graph.add_edge(machine1.idx, machine2.idx)
+        idx1 = self.machines.index(machine1)
+        idx2 = self.machines.index(machine2)
+        self._machine_graph.add_edge(idx1, idx2)

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -110,12 +110,10 @@ class Model:
         """
         job_idx = self.jobs.index(job)
         machine_idcs = [self.machines.index(m) for m in machines]
-        operation = Operation(
-            len(self.operations), job_idx, machine_idcs, durations, name
-        )
+        operation = Operation(job_idx, machine_idcs, durations, name)
 
         self._operations.append(operation)
-        self._operations_graph.add_node(operation.idx)
+        self._operations_graph.add_node(len(self.operations))
 
         return operation
 
@@ -132,7 +130,9 @@ class Model:
             raise ValueError(msg)
 
         self._operations_graph.add_edge(
-            operation1.idx, operation2.idx, precedence_types=precedence_types
+            self.operations.index(operation1),
+            self.operations.index(operation2),
+            precedence_types=precedence_types,
         )
 
     def add_machines_edge(self, machine1: Machine, machine2: Machine):

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -90,8 +90,8 @@ class Model:
         machine = Machine(name)
 
         idx = len(self.machines)
-        self._machine_graph.add_node(idx)
         self._id2machine[id(machine)] = idx
+        self._machine_graph.add_node(idx)
         self._machines.append(machine)
 
         return machine
@@ -122,8 +122,8 @@ class Model:
         operation = Operation(job_idx, machine_idcs, durations, name)
 
         idx = len(self.operations)
-        self._operations_graph.add_node(idx)
         self._id2op[id(operation)] = idx
+        self._operations_graph.add_node(idx)
         self._operations.append(operation)
 
         return operation

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -17,6 +17,10 @@ class Model:
         self._machine_graph = nx.DiGraph()
         self._operations_graph = nx.DiGraph()
 
+        self._id2job = {}
+        self._id2machine = {}
+        self._id2op = {}
+
     @property
     def jobs(self) -> list[Job]:
         return self._jobs
@@ -68,7 +72,10 @@ class Model:
             Optional name of the job.
         """
         job = Job(release_date, deadline, name)
+
+        self._id2job[id(job)] = len(self.jobs)
         self._jobs.append(job)
+
         return job
 
     def add_machine(self, name: Optional[str] = None) -> Machine:
@@ -82,8 +89,10 @@ class Model:
         """
         machine = Machine(name)
 
+        idx = len(self.machines)
+        self._machine_graph.add_node(idx)
+        self._id2machine[id(machine)] = idx
         self._machines.append(machine)
-        self._machine_graph.add_node(len(self.machines))
 
         return machine
 
@@ -108,12 +117,14 @@ class Model:
         name: Optional[str]
             Optional name of the operation.
         """
-        job_idx = self.jobs.index(job)
-        machine_idcs = [self.machines.index(m) for m in machines]
+        job_idx = self._id2job[id(job)]
+        machine_idcs = [self._id2machine[id(m)] for m in machines]
         operation = Operation(job_idx, machine_idcs, durations, name)
 
+        idx = len(self.operations)
+        self._operations_graph.add_node(idx)
+        self._id2op[id(operation)] = idx
         self._operations.append(operation)
-        self._operations_graph.add_node(len(self.operations))
 
         return operation
 

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -16,10 +16,11 @@ class Model:
         self._operations = []
         self._machine_graph = nx.DiGraph()
         self._operations_graph = nx.DiGraph()
+        self._processing_times: dict[tuple[int, int], int] = {}
 
-        self._id2job = {}
-        self._id2machine = {}
-        self._id2op = {}
+        self._id2job: dict[int, int] = {}
+        self._id2machine: dict[int, int] = {}
+        self._id2op: dict[int, int] = {}
 
     @property
     def jobs(self) -> list[Job]:
@@ -51,6 +52,7 @@ class Model:
             self.operations,
             self.machine_graph,
             self.operations_graph,
+            self._processing_times,
         )
 
     def add_job(
@@ -97,11 +99,7 @@ class Model:
         return machine
 
     def add_operation(
-        self,
-        job: Job,
-        machines: list[Machine],
-        durations: list[int],
-        name: Optional[str] = None,
+        self, job: Job, machines: list[Machine], name: Optional[str] = None
     ) -> Operation:
         """
         Adds an operation to the model.
@@ -112,14 +110,12 @@ class Model:
             Job to which the operation belongs.
         machines: list[Machine]
             Eligible machines that can process the operation.
-        durations: list[int]
-            Durations of the operation on each machine.
         name: Optional[str]
             Optional name of the operation.
         """
         job_idx = self._id2job[id(job)]
         machine_idcs = [self._id2machine[id(m)] for m in machines]
-        operation = Operation(job_idx, machine_idcs, durations, name)
+        operation = Operation(job_idx, machine_idcs, name)
 
         idx = len(self.operations)
         self._id2op[id(operation)] = idx
@@ -150,3 +146,11 @@ class Model:
         idx1 = self.machines.index(machine1)
         idx2 = self.machines.index(machine2)
         self._machine_graph.add_edge(idx1, idx2)
+
+    def add_processing_time(
+        self, operation: Operation, machine: Machine, duration: int
+    ):
+        op_idx = self._id2op[id(operation)]
+        machine_idx = self._id2machine[id(machine)]
+
+        self._processing_times[op_idx, machine_idx] = duration

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -67,12 +67,7 @@ class Model:
         name: Optional[str]
             Optional name of the job.
         """
-        job = Job(
-            len(self.jobs),
-            release_date=release_date,
-            deadline=deadline,
-            name=name,
-        )
+        job = Job(release_date=release_date, deadline=deadline, name=name)
         self._jobs.append(job)
         return job
 

--- a/fjsp/Model.py
+++ b/fjsp/Model.py
@@ -113,8 +113,10 @@ class Model:
         name: Optional[str]
             Optional name of the operation.
         """
+        job_idx = self.jobs.index(job)
+        machine_idcs = [self.machines.index(m) for m in machines]
         operation = Operation(
-            len(self.operations), job, machines, durations, name
+            len(self.operations), job_idx, machine_idcs, durations, name
         )
 
         self._operations.append(operation)

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -144,7 +144,7 @@ class ProblemData:
         self._jobs = jobs
         self._machines = machines
         self._operations = operations
-        self._machine_graph = machine_graph  # TODO can we replace digraph?
+        self._machine_graph = machine_graph
         self._operations_graph = operations_graph
 
         self._job2ops: list[list[int]] = [[] for _ in range(self.num_jobs)]
@@ -152,11 +152,11 @@ class ProblemData:
             [] for _ in range(self.num_machines)
         ]
 
-        for op_idx, op in enumerate(operations):
-            self._job2ops[op.job].append(op_idx)
+        for op, op_data in enumerate(self.operations):
+            self._job2ops[op_data.job].append(op)
 
-            for m in op.machines:
-                self._machine2ops[m].append(op_idx)
+            for m in op_data.machines:
+                self._machine2ops[m].append(op)
 
     @property
     def jobs(self) -> list[Job]:

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -151,44 +151,106 @@ class ProblemData:
 
     @property
     def jobs(self) -> list[Job]:
+        """
+        Returns the job data of this problem instance.
+        """
         return self._jobs
 
     @property
     def machines(self) -> list[Machine]:
+        """
+        Returns the machine data of this problem instance.
+        """
         return self._machines
 
     @property
     def operations(self) -> list[Operation]:
+        """
+        Returns the operation data of this problem instance.
+        """
         return self._operations
 
     @property
     def machine_graph(self) -> nx.DiGraph:
+        """
+        Directed graph of machines accesibility constraints. An arc (i, j)
+        represents that machine i can be accessed from machine j.
+
+        Returns
+        -------
+        nx.DiGraph
+            Directed graph of machines accesibility constraints.
+        """
         return self._machine_graph
 
     @property
     def operations_graph(self) -> nx.DiGraph:
+        """
+        Directed graph of operations precedence constraints. Each arc (i, j)
+        represents a set of precedence constraints between operations i and j,
+        which are stored in the attribute ``precendence_types`` of the arc.
+
+        Returns
+        -------
+        nx.DiGraph
+            Directed graph of operations precedence constraints.
+        """
         return self._operations_graph
 
     @property
     def processing_times(self) -> dict[tuple[int, int], int]:
+        """
+        Processing times of operations on machines.
+
+        Returns
+        -------
+        dict[tuple[int, int], int]
+            Processing times of operations on machines. The dictionary is
+            indexed by tuples of the form (operation_idx, machine_idx).
+        """
         return self._processing_times
 
     @property
     def job2ops(self) -> list[list[int]]:
+        """
+        List of operation indices for each job.
+
+        Returns
+        -------
+        list[list[int]]
+            List of operation indices for each job.
+        """
         return self._job2ops
 
     @property
     def machine2ops(self) -> list[list[int]]:
+        """
+        List of operation indices for each machine.
+
+        Returns
+        -------
+        list[list[int]]
+            List of operation indices for each machine.
+        """
         return self._machine2ops
 
     @property
     def num_jobs(self) -> int:
+        """
+        Returns the number of jobs in this instance.
+        """
         return len(self._jobs)
 
     @property
     def num_machines(self) -> int:
+        """
+        Returns the number of machines in this instance.
+        """
         return len(self._machines)
 
     @property
     def num_operations(self) -> int:
+        """
+        Returns the number of operations in this instance.
+        """
         return len(self._operations)

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -5,15 +5,19 @@ from typing import Optional
 import networkx as nx
 
 
-@dataclass(frozen=True, eq=True)
 class Job:
-    idx: int
-    release_date: int = 0
-    deadline: Optional[int] = None
-    name: Optional[str] = None
+    def __init__(
+        self,
+        release_date: int = 0,
+        deadline: Optional[int] = None,
+        name: Optional[str] = None,
+    ):
+        self.release_date = release_date
+        self.deadline = deadline
+        self.name = name
 
     def __str__(self):
-        return self.name if self.name else f"Job {self.idx}"
+        return self.name if self.name else "Job"
 
 
 @dataclass(frozen=True, eq=True)

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -12,32 +12,45 @@ class Job:
         deadline: Optional[int] = None,
         name: Optional[str] = None,
     ):
-        self.release_date = release_date
-        self.deadline = deadline
-        self.name = name
+        self._release_date = release_date
+        self._deadline = deadline
+        self._name = name or "Job"
 
-    def __str__(self):
-        return self.name if self.name else "Job"
+    @property
+    def release_date(self) -> int:
+        return self._release_date
+
+    @property
+    def deadline(self) -> Optional[int]:
+        return self._deadline
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __str__(self) -> str:
+        return self.name
 
 
-@dataclass(frozen=True, eq=True)
 class Machine:
     """
-    A machine is a resource that can process operations.
+    A machine represents a resource that can process operations.
 
     Parameters
     ----------
-    idx: int
-        Unique identifier of the machine.
     name: Optional[str]
-        Name of the machine. If not provided, the name will be "Machine {idx}".
+        Optional name of the machine.
     """
 
-    idx: int
-    name: Optional[str] = None
+    def __init__(self, name: Optional[str] = None):
+        self._name = name or "Machine"
 
-    def __str__(self):
-        return self.name if self.name else f"Machine {self.idx}"
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __str__(self) -> str:
+        return self.name
 
 
 @dataclass(frozen=True, eq=True)

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
 from typing import Optional
@@ -120,14 +119,16 @@ class ProblemData:
         self._machine_graph = machine_graph  # TODO can we replace digraph?
         self._operations_graph = operations_graph
 
-        self._job2ops = defaultdict(list)
-        self._machine2ops = defaultdict(list)
+        self._job2ops: list[list[int]] = [[] for _ in range(self.num_jobs)]
+        self._machine2ops: list[list[int]] = [
+            [] for _ in range(self.num_machines)
+        ]
 
         for op in operations:
-            self._job2ops[op.job].append(op.idx)
+            self._job2ops[op.job.idx].append(op.idx)
 
             for m in op.machines:
-                self._machine2ops[m].append(op.idx)
+                self._machine2ops[m.idx].append(op.idx)
 
     @property
     def jobs(self) -> list[Job]:
@@ -150,11 +151,11 @@ class ProblemData:
         return self._operations_graph
 
     @property
-    def job2ops(self) -> dict[Job, list[int]]:
+    def job2ops(self) -> list[list[int]]:
         return self._job2ops
 
     @property
-    def machine2ops(self) -> dict[Machine, list[int]]:
+    def machine2ops(self) -> list[list[int]]:
         return self._machine2ops
 
     @property

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -124,10 +124,10 @@ class ProblemData:
         self._machine2ops = defaultdict(list)
 
         for op in operations:
-            self._job2ops[op.job].append(op)
+            self._job2ops[op.job].append(op.idx)
 
             for m in op.machines:
-                self._machine2ops[m].append(op)
+                self._machine2ops[m].append(op.idx)
 
     @property
     def jobs(self) -> list[Job]:
@@ -150,11 +150,11 @@ class ProblemData:
         return self._operations_graph
 
     @property
-    def job2ops(self) -> dict[Job, list[Operation]]:
+    def job2ops(self) -> dict[Job, list[int]]:
         return self._job2ops
 
     @property
-    def machine2ops(self) -> dict[Machine, list[Operation]]:
+    def machine2ops(self) -> dict[Machine, list[int]]:
         return self._machine2ops
 
     @property

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -171,11 +171,11 @@ class ProblemData:
         return self._operations
 
     @property
-    def machine_graph(self):
+    def machine_graph(self) -> nx.DiGraph:
         return self._machine_graph
 
     @property
-    def operations_graph(self):
+    def operations_graph(self) -> nx.DiGraph:
         return self._operations_graph
 
     @property

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -42,14 +42,11 @@ class Machine:
     """
 
     def __init__(self, name: Optional[str] = None):
-        self._name = name or "Machine"
+        self._name = name
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         return self._name
-
-    def __str__(self) -> str:
-        return self.name
 
 
 class Operation:
@@ -78,7 +75,7 @@ class Operation:
         self._job = job
         self._machines = machines
         self._durations = durations
-        self._name = name or "Operation"
+        self._name = name
 
     @property
     def job(self) -> int:
@@ -93,11 +90,8 @@ class Operation:
         return self._durations
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         return self._name
-
-    def __str__(self):
-        return self.name
 
 
 class PrecedenceTypeMeta(EnumMeta):

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -59,22 +59,15 @@ class Operation:
         Index of the job to which the operation belongs.
     machines: list[int]
         Indices of machines that can process the operation.
-    durations: list[int]
-        Durations of the operation on each machine.
     name: Optional[str]
         Name of the operation.
     """
 
     def __init__(
-        self,
-        job: int,
-        machines: list[int],
-        durations: list[int],
-        name: Optional[str] = None,
+        self, job: int, machines: list[int], name: Optional[str] = None
     ):
         self._job = job
         self._machines = machines
-        self._durations = durations
         self._name = name
 
     @property
@@ -84,10 +77,6 @@ class Operation:
     @property
     def machines(self) -> list[int]:
         return self._machines
-
-    @property
-    def durations(self) -> list[int]:
-        return self._durations
 
     @property
     def name(self) -> Optional[str]:
@@ -140,12 +129,14 @@ class ProblemData:
         operations: list[Operation],
         machine_graph: nx.DiGraph,
         operations_graph: nx.DiGraph,
+        processing_times: dict[tuple[int, int], int],
     ):
         self._jobs = jobs
         self._machines = machines
         self._operations = operations
         self._machine_graph = machine_graph
         self._operations_graph = operations_graph
+        self._processing_times = processing_times
 
         self._job2ops: list[list[int]] = [[] for _ in range(self.num_jobs)]
         self._machine2ops: list[list[int]] = [
@@ -177,6 +168,10 @@ class ProblemData:
     @property
     def operations_graph(self) -> nx.DiGraph:
         return self._operations_graph
+
+    @property
+    def processing_times(self) -> dict[tuple[int, int], int]:
+        return self._processing_times
 
     @property
     def job2ops(self) -> list[list[int]]:

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -45,10 +45,10 @@ class Operation:
     ----------
     idx: int
         Unique identifier of the operation.
-    job: Job
-        Job to which the operation belongs.
-    machines: list[Machine]
-        Machines that can process the operation.
+    job: int
+        Index of the job to which the operation belongs.
+    machines: list[int]
+        Indices of machines that can process the operation.
     durations: list[int]
         Durations of the operation on each machine.
     name: Optional[str]
@@ -57,8 +57,8 @@ class Operation:
     """
 
     idx: int
-    job: Job
-    machines: list[Machine]
+    job: int
+    machines: list[int]
     durations: list[int]
     name: Optional[str] = None
 
@@ -125,10 +125,10 @@ class ProblemData:
         ]
 
         for op in operations:
-            self._job2ops[op.job.idx].append(op.idx)
+            self._job2ops[op.job].append(op.idx)
 
             for m in op.machines:
-                self._machine2ops[m.idx].append(op.idx)
+                self._machine2ops[m].append(op.idx)
 
     @property
     def jobs(self) -> list[Job]:

--- a/fjsp/ProblemData.py
+++ b/fjsp/ProblemData.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from enum import Enum, EnumMeta
 from typing import Optional
 
@@ -53,15 +52,12 @@ class Machine:
         return self.name
 
 
-@dataclass(frozen=True, eq=True)
 class Operation:
     """
     An operation is a task that must be processed by a machine.
 
     Parameters
     ----------
-    idx: int
-        Unique identifier of the operation.
     job: int
         Index of the job to which the operation belongs.
     machines: list[int]
@@ -69,18 +65,39 @@ class Operation:
     durations: list[int]
         Durations of the operation on each machine.
     name: Optional[str]
-        Name of the operation. If not provided, the name will be
-        "Operation {idx}".
+        Name of the operation.
     """
 
-    idx: int
-    job: int
-    machines: list[int]
-    durations: list[int]
-    name: Optional[str] = None
+    def __init__(
+        self,
+        job: int,
+        machines: list[int],
+        durations: list[int],
+        name: Optional[str] = None,
+    ):
+        self._job = job
+        self._machines = machines
+        self._durations = durations
+        self._name = name or "Operation"
+
+    @property
+    def job(self) -> int:
+        return self._job
+
+    @property
+    def machines(self) -> list[int]:
+        return self._machines
+
+    @property
+    def durations(self) -> list[int]:
+        return self._durations
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     def __str__(self):
-        return self.name if self.name else f"Operation {self.idx}"
+        return self.name
 
 
 class PrecedenceTypeMeta(EnumMeta):
@@ -141,11 +158,11 @@ class ProblemData:
             [] for _ in range(self.num_machines)
         ]
 
-        for op in operations:
-            self._job2ops[op.job].append(op.idx)
+        for op_idx, op in enumerate(operations):
+            self._job2ops[op.job].append(op_idx)
 
             for m in op.machines:
-                self._machine2ops[m].append(op.idx)
+                self._machine2ops[m].append(op_idx)
 
     @property
     def jobs(self) -> list[Job]:

--- a/fjsp/Solution.py
+++ b/fjsp/Solution.py
@@ -25,10 +25,9 @@ class ScheduledOperation:
         self._start = start
         self._duration = duration
 
-        if assigned_machine not in [machine.idx for machine in op.machines]:
-            raise ValueError(
-                f"Operation {op} cannot be assigned to machine {assigned_machine}."
-            )
+        if assigned_machine not in list(op.machines):
+            msg = f"Operation {op} not allowed on machine {assigned_machine}."
+            raise ValueError(msg)
 
     @property
     def op(self) -> Operation:

--- a/fjsp/cp/constraints.py
+++ b/fjsp/cp/constraints.py
@@ -6,7 +6,7 @@ from docplex.cp.model import CpoModel
 from fjsp.ProblemData import ProblemData
 
 OpsVars = list[CpoIntervalVar]
-AssignVars = dict[int, dict[int, CpoIntervalVar]]
+AssignVars = dict[tuple[int, int], CpoIntervalVar]
 SeqVars = list[CpoSequenceVar]
 
 
@@ -56,8 +56,8 @@ def assignment_precedence_constraints(
             if op1 == op2 or (op1, op2) not in data.operations_graph.edges:
                 continue
 
-            var1 = assign[op1][machine]
-            var2 = assign[op2][machine]
+            var1 = assign[op1, machine]
+            var2 = assign[op2, machine]
             edge = data.operations_graph.edges[op1, op2]
 
             for prec_type in edge["precedence_types"]:
@@ -85,7 +85,7 @@ def alternative_constraints(
     constraints = []
 
     for op in range(data.num_operations):
-        optional = [assign[op][mach] for mach in data.operations[op].machines]
+        optional = [assign[op, mach] for mach in data.operations[op].machines]
         constraints.append(m.alternative(ops[op], optional))
 
     return constraints
@@ -119,8 +119,8 @@ def machine_accessibility_constraints(
             if (mach1, mach2) not in data.machine_graph.edges:
                 # If (m1 -> m2) is not an edge in the machine graph, then
                 # we cannot schedule operation 1 on m1 and operation 2 on m2.
-                frm = assign[op1][mach1]
-                to = assign[op2][mach2]
+                frm = assign[op1, mach1]
+                to = assign[op2, mach2]
                 constraints.append(m.presence_of(frm) + m.presence_of(to) <= 1)
 
     return constraints

--- a/fjsp/cp/constraints.py
+++ b/fjsp/cp/constraints.py
@@ -86,7 +86,7 @@ def alternative_constraints(
 
     for op in data.operations:
         op_var = ops[op.idx]
-        optional = [assign[op.idx][mach.idx] for mach in op.machines]
+        optional = [assign[op.idx][machine] for machine in op.machines]
         constraints.append(m.alternative(op_var, optional))
 
     return constraints
@@ -116,7 +116,7 @@ def machine_accessibility_constraints(
         op1, op2 = data.operations[i], data.operations[j]
 
         for m1, m2 in product(op1.machines, op2.machines):
-            if (m1.idx, m2.idx) not in data.machine_graph.edges:
+            if (m1, m2) not in data.machine_graph.edges:
                 # If (m1 -> m2) is not an edge in the machine graph, then
                 # we cannot schedule operation 1 on m1 and operation 2 on m2.
                 frm = assign[op1.idx][m1.idx]

--- a/fjsp/cp/constraints.py
+++ b/fjsp/cp/constraints.py
@@ -99,7 +99,7 @@ def no_overlap_constraints(
     Creates the no-overlap constraints for machines, ensuring that no two
     intervals in a sequence variable are overlapping.
     """
-    return [m.no_overlap(sequences[machine.idx]) for machine in data.machines]
+    return [m.no_overlap(sequences[mach]) for mach in range(data.num_machines)]
 
 
 def machine_accessibility_constraints(

--- a/fjsp/cp/constraints.py
+++ b/fjsp/cp/constraints.py
@@ -49,15 +49,15 @@ def assignment_precedence_constraints(
 ) -> list[CpoExpr]:
     constraints = []
 
-    for machine, ops in data.machine2ops.items():
-        seq_var = sequence[machine.idx]
+    for machine, ops in enumerate(data.machine2ops):
+        seq_var = sequence[machine]
 
         for op1, op2 in product(ops, repeat=2):
             if op1 == op2 or (op1, op2) not in data.operations_graph.edges:
                 continue
 
-            var1 = assign[op1][machine.idx]
-            var2 = assign[op2][machine.idx]
+            var1 = assign[op1][machine]
+            var2 = assign[op2][machine]
             edge = data.operations_graph.edges[op1, op2]
 
             for prec_type in edge["precedence_types"]:

--- a/fjsp/cp/constraints.py
+++ b/fjsp/cp/constraints.py
@@ -53,15 +53,12 @@ def assignment_precedence_constraints(
         seq_var = sequence[machine.idx]
 
         for op1, op2 in product(ops, repeat=2):
-            if op1 == op2:
+            if op1 == op2 or (op1, op2) not in data.operations_graph.edges:
                 continue
 
-            if (op1.idx, op2.idx) not in data.operations_graph.edges:
-                continue
-
-            var1 = assign[op1.idx][machine.idx]
-            var2 = assign[op2.idx][machine.idx]
-            edge = data.operations_graph.edges[op1.idx, op2.idx]
+            var1 = assign[op1][machine.idx]
+            var2 = assign[op2][machine.idx]
+            edge = data.operations_graph.edges[op1, op2]
 
             for prec_type in edge["precedence_types"]:
                 if prec_type == "previous":

--- a/fjsp/cp/constraints.py
+++ b/fjsp/cp/constraints.py
@@ -84,10 +84,9 @@ def alternative_constraints(
     """
     constraints = []
 
-    for op in data.operations:
-        op_var = ops[op.idx]
-        optional = [assign[op.idx][machine] for machine in op.machines]
-        constraints.append(m.alternative(op_var, optional))
+    for op in range(data.num_operations):
+        optional = [assign[op][mach] for mach in data.operations[op].machines]
+        constraints.append(m.alternative(ops[op], optional))
 
     return constraints
 
@@ -112,15 +111,16 @@ def machine_accessibility_constraints(
     """
     constraints = []
 
-    for i, j in data.operations_graph.edges:
-        op1, op2 = data.operations[i], data.operations[j]
+    for op1, op2 in data.operations_graph.edges:
+        machines1 = data.operations[op1].machines
+        machines2 = data.operations[op2].machines
 
-        for m1, m2 in product(op1.machines, op2.machines):
-            if (m1, m2) not in data.machine_graph.edges:
+        for mach1, mach2 in product(machines1, machines2):
+            if (mach1, mach2) not in data.machine_graph.edges:
                 # If (m1 -> m2) is not an edge in the machine graph, then
                 # we cannot schedule operation 1 on m1 and operation 2 on m2.
-                frm = assign[op1.idx][m1.idx]
-                to = assign[op2.idx][m2.idx]
+                frm = assign[op1][mach1]
+                to = assign[op2][mach2]
                 constraints.append(m.presence_of(frm) + m.presence_of(to) <= 1)
 
     return constraints

--- a/fjsp/cp/objectives.py
+++ b/fjsp/cp/objectives.py
@@ -24,7 +24,7 @@ def total_completion_time(
     completion_times = []
 
     for _, operations in data.job2ops.items():
-        expr = m.max([ops[op.idx] for op in operations])
+        expr = m.max([ops[op] for op in operations])
         completion_times.append(expr)
 
     return m.minimize(m.sum(completion_times))
@@ -41,7 +41,7 @@ def total_tardiness(
     total = []
 
     for job, operations in data.job2ops.items():
-        expr = m.max([m.end_of(ops[op.idx]) for op in operations])
+        expr = m.max([m.end_of(ops[op]) for op in operations])
         tardiness = m.max(0, expr - data.jobs[job.idx].deadline)
         total.append(tardiness)
 

--- a/fjsp/cp/objectives.py
+++ b/fjsp/cp/objectives.py
@@ -23,7 +23,7 @@ def total_completion_time(
     """
     completion_times = []
 
-    for _, operations in data.job2ops.items():
+    for operations in data.job2ops:
         expr = m.max([ops[op] for op in operations])
         completion_times.append(expr)
 
@@ -40,9 +40,9 @@ def total_tardiness(
     """
     total = []
 
-    for job, operations in data.job2ops.items():
+    for job, operations in enumerate(data.job2ops):
         expr = m.max([m.end_of(ops[op]) for op in operations])
-        tardiness = m.max(0, expr - data.jobs[job.idx].deadline)
+        tardiness = m.max(0, expr - data.jobs[job].deadline)
         total.append(tardiness)
 
     return m.minimize(m.sum(total))

--- a/fjsp/cp/variables.py
+++ b/fjsp/cp/variables.py
@@ -23,14 +23,15 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
     variables = {}
 
     for op, op_data in enumerate(data.operations):
-        for idx, machine in enumerate(op_data.machines):
+        for machine in op_data.machines:
             var = m.interval_var(name=f"A{op}_{machine}", optional=True)
             variables[op, machine] = var
 
             # The duration of the operation on the machine is at least the
             # duration of the operation; it could be longer due to blocking.
             m.add(
-                m.size_of(var) >= op_data.durations[idx] * m.presence_of(var)
+                m.size_of(var)
+                >= data.processing_times[op, machine] * m.presence_of(var)
             )
 
             # Operation may not start before the job's release date if present.

--- a/fjsp/cp/variables.py
+++ b/fjsp/cp/variables.py
@@ -51,10 +51,8 @@ def sequence_variables(
     """
     variables = []
 
-    for machine, operations in data.machine2ops.items():
-        intervals = [assign[op][machine.idx] for op in operations]
-        variables.append(
-            m.sequence_var(name=f"S{machine.idx}", vars=intervals)
-        )
+    for machine, operations in enumerate(data.machine2ops):
+        intervals = [assign[op][machine] for op in operations]
+        variables.append(m.sequence_var(name=f"S{machine}", vars=intervals))
 
     return variables

--- a/fjsp/cp/variables.py
+++ b/fjsp/cp/variables.py
@@ -25,17 +25,18 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
         op_vars = {}
 
         for idx, machine in enumerate(op.machines):
-            var = m.interval_var(
-                name=f"A{op.idx}_{machine.idx}", optional=True
-            )
-            op_vars[machine.idx] = var
+            var = m.interval_var(name=f"A{op.idx}_{machine}", optional=True)
+            op_vars[machine] = var
 
             # The duration of the operation on the machine is at least the
             # duration of the operation; it could be longer due to blocking.
             m.add(m.size_of(var) >= op.durations[idx] * m.presence_of(var))
 
             # Operation may not start before the job's release date if present.
-            m.add(m.start_of(var) >= op.job.release_date * m.presence_of(var))
+            m.add(
+                m.start_of(var)
+                >= data.jobs[op.job].release_date * m.presence_of(var)
+            )
 
         variables[op.idx] = op_vars
 

--- a/fjsp/cp/variables.py
+++ b/fjsp/cp/variables.py
@@ -22,24 +22,26 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
     """
     variables = {}
 
-    for op_idx, op in enumerate(data.operations):
+    for op, op_data in enumerate(data.operations):
         op_vars = {}
 
-        for idx, machine in enumerate(op.machines):
-            var = m.interval_var(name=f"A{op_idx}_{machine}", optional=True)
+        for idx, machine in enumerate(op_data.machines):
+            var = m.interval_var(name=f"A{op}_{machine}", optional=True)
             op_vars[machine] = var
 
             # The duration of the operation on the machine is at least the
             # duration of the operation; it could be longer due to blocking.
-            m.add(m.size_of(var) >= op.durations[idx] * m.presence_of(var))
+            m.add(
+                m.size_of(var) >= op_data.durations[idx] * m.presence_of(var)
+            )
 
             # Operation may not start before the job's release date if present.
             m.add(
                 m.start_of(var)
-                >= data.jobs[op.job].release_date * m.presence_of(var)
+                >= data.jobs[op_data.job].release_date * m.presence_of(var)
             )
 
-        variables[op_idx] = op_vars
+        variables[op] = op_vars
 
     return variables
 

--- a/fjsp/cp/variables.py
+++ b/fjsp/cp/variables.py
@@ -21,11 +21,12 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
     machine pair.
     """
     variables = {}
-    for op in data.operations:
+
+    for op_idx, op in enumerate(data.operations):
         op_vars = {}
 
         for idx, machine in enumerate(op.machines):
-            var = m.interval_var(name=f"A{op.idx}_{machine}", optional=True)
+            var = m.interval_var(name=f"A{op_idx}_{machine}", optional=True)
             op_vars[machine] = var
 
             # The duration of the operation on the machine is at least the
@@ -38,7 +39,7 @@ def assignment_variables(m: CpoModel, data: ProblemData) -> AssignVars:
                 >= data.jobs[op.job].release_date * m.presence_of(var)
             )
 
-        variables[op.idx] = op_vars
+        variables[op_idx] = op_vars
 
     return variables
 

--- a/fjsp/cp/variables.py
+++ b/fjsp/cp/variables.py
@@ -51,8 +51,8 @@ def sequence_variables(
     """
     variables = []
 
-    for machine, ops in data.machine2ops.items():
-        intervals = [assign[op.idx][machine.idx] for op in ops]
+    for machine, operations in data.machine2ops.items():
+        intervals = [assign[op][machine.idx] for op in operations]
         variables.append(
             m.sequence_var(name=f"S{machine.idx}", vars=intervals)
         )

--- a/fjsp/plot.py
+++ b/fjsp/plot.py
@@ -30,7 +30,7 @@ def plot(data: ProblemData, solution: Solution, plot_labels: bool = True):
         )
 
         # Plot each scheduled operation as a single horizontal bar (interval).
-        color = colors[op.job.idx]
+        color = colors[op.job]
         kwargs = {"color": color, "linewidth": 1, "edgecolor": "black"}
         ax.barh(machine, duration, left=start, **kwargs)
 

--- a/fjsp/plot.py
+++ b/fjsp/plot.py
@@ -5,7 +5,7 @@ from .ProblemData import ProblemData
 from .Solution import Solution
 
 
-def plot(data: ProblemData, solution: Solution, plot_labels: bool = True):
+def plot(data: ProblemData, solution: Solution, plot_labels: bool = False):
     """
     Plots a Gantt chart of the solver result.
 
@@ -35,11 +35,14 @@ def plot(data: ProblemData, solution: Solution, plot_labels: bool = True):
         ax.barh(machine, duration, left=start, **kwargs)
 
         if plot_labels:
-            # Add the operation ID at the center of the interval.
+            # Plot the operation name as label in the center of the interval.
             center = start + duration / 2
             ax.text(center, machine, op.name, ha="center", va="center")
 
-    labels = [str(machine) for machine in data.machines]
+    labels = [
+        machine.name or f"Machine {idx}"
+        for idx, machine in enumerate(data.machines, 1)
+    ]
     ax.set_yticks(ticks=range(len(data.machines)), labels=labels)
     ax.set_ylim(ax.get_ylim()[::-1])
 

--- a/fjsp/plot.py
+++ b/fjsp/plot.py
@@ -37,7 +37,7 @@ def plot(data: ProblemData, solution: Solution, plot_labels: bool = True):
         if plot_labels:
             # Add the operation ID at the center of the interval.
             center = start + duration / 2
-            ax.text(center, machine, op.idx, ha="center", va="center")
+            ax.text(center, machine, op.name, ha="center", va="center")
 
     labels = [str(machine) for machine in data.machines]
     ax.set_yticks(ticks=range(len(data.machines)), labels=labels)


### PR DESCRIPTION
This is a follow-up PR on #33 to simplify the code. It gets rid of the indices on Job, Machine and Operations, which I initially used since I did not have a convention yet for indexing.

It also separates the processing times from the `Operation` object.